### PR TITLE
Add jsfiddle examples

### DIFF
--- a/appcache.manifest
+++ b/appcache.manifest
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# Wed Jun 15 18:00:38 UTC 2011
+# Wed Jun 15 18:01:17 UTC 2011
 
 
 # cache all of these

--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@
         </div>
 
         <p>{{examples[selected].description}}</p>
+        <p>You can mess aroung with this example on <a ng:href="http://jsfiddle.net/{{examples[selected].fiddle}}" target="_blank">fiddle</a>. Or you can build your own example from <a href="http://jsfiddle.net/vojtajina/CHVbb/" target="_blank">scratch</a>.</p>
 
         <!-- Password Strength example -->
         <div ng:show="selected == 0">

--- a/js/app.js
+++ b/js/app.js
@@ -131,8 +131,8 @@ ExamplesCtrl.prototype = {
   next: function() {
     this.selected = (this.selected + 1) % this.examples.length;
   },
-  examples: [{title: 'Password', description: 'The following is a demo password generator app that showcases angular\'s rich declarative templates, data-binding, MVC, xhr service, and depenency injection.'},
-             {title: 'Invoice', description: 'The following is a demo invoicing app built only with angular\'s declarative templates, data-binding, filters, and validators.'}]
+  examples: [{title: 'Password', fiddle: 'vojtajina/76E4S/', description: 'The following is a demo password generator app that showcases angular\'s rich declarative templates, data-binding, MVC, xhr service, and depenency injection.'},
+             {title: 'Invoice', fiddle: 'vojtajina/pfqKY/', description: 'The following is a demo invoicing app built only with angular\'s declarative templates, data-binding, filters, and validators.'}]
 };
 
 // syntax highlighter defaults


### PR DESCRIPTION
I've been thinking where we could put the link to jsfiddle...
This is just one idea - I created both live examples on fiddle and added link along with link to empty angular project...

Please change the text, I'm very poor writer :-D

I'm using my jsfiddle account - I have absolutely no problem with that. But guess would be better to create _angular_ user - but registration requires valid e-mail...
