### PR TITLE
Fix links to the CDN-hosted AngularJS files

### DIFF
--- a/js/homepage.js
+++ b/js/homepage.js
@@ -82,8 +82,8 @@ angular.module('homepage', [])
   .factory('script', function() {
 
     return {
-      angular: '<script src="//ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular.min.js"></script>\n',
-      resource: '<script src="//ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular-resource.min.js"></script>\n'
+      angular: '<script src="http://ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular.min.js"></script>\n',
+      resource: '<script src="http://ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular-resource.min.js"></script>\n'
     };
   })
 


### PR DESCRIPTION
All the links to the AngularJS files were missing a protocol. This was causing problems for people coping & pasting code and trying to run it using the file:// protocol.
