### PR TITLE
Fix broken youtube tutorial links on main page

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -166,7 +166,6 @@ img.cache {
   margin: 0;
 }
 
-
 .no-margins {
   margin-top: 0px!important;
   margin-bottom: 0px!important;
@@ -178,13 +177,13 @@ img.cache {
 .modal.fade.in {
     top: 40%;
 }
-.modal-backdrop {
+#downloadModalBackdrop {
     display: none;
     z-index: -2000;
 }
-.modal-backdrop.fade.in {
+#downloadModalBackdrop.fade.in {
     display: block;
-    z-index: 1000;
+    z-index: 1040;
 }
 
 .popover {

--- a/index.html
+++ b/index.html
@@ -930,6 +930,6 @@
       <a class="btn btn-primary btn-large" style="float: right; font-size: 20px; padding-left: 20px;" ng-href="{{downloadLink()}}" download><i class="icon-download-alt icon-large"></i> Download</a>
     </div>
   </div>
-  <div class="modal-backdrop fade" ng-class="{in: lightbox()}" ng-click='lightbox(false)'></div>
+  <div id="downloadModalBackdrop" class="modal-backdrop fade" ng-class="{in: lightbox()}" ng-click='lightbox(false)'></div>
 </body>
 </html>


### PR DESCRIPTION
This fixes the missing youtube tutorial video which had been broken due to an improper css style in the new download modal.
