### PR TITLE
Fixing tooltip url to bower

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,7 +890,7 @@
         <dd>
           <span class="input-append">
             <input class="input-xxlarge" type="text" readonly="readonly" value="bower install angular">
-            <a id="extraInfoBower" href="" rel="popover" data-original-title="What is Bower?" data-content="Bower is a package manager for client-side JavaScript components.<br><br>For more info please see: http://twitter.github.com/bower/"><i class="icon-question-sign"></i></a>
+            <a id="extraInfoBower" href="" rel="popover" data-original-title="What is Bower?" data-content="Bower is a package manager for client-side JavaScript components.<br><br>For more info please see: https://github.com/bower/bower"><i class="icon-question-sign"></i></a>
           </span>
         </dd>
       </dl>


### PR DESCRIPTION
Link to bower repo was outdated, current github url added in place
