### PR TITLE
Prevent delete button from activating when Enter is pressed

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@
         <a href="#/" class="btn">Cancel</a>
         <button ng-click="save()" ng-disabled="isClean() || myForm.$invalid"
                 class="btn btn-primary">Save</button>
-        <button ng-click="destroy()"
+        <button type="button" ng-click="destroy()"
                 ng-show="project.$id" class="btn btn-danger">Delete</button>
       </form>
     </script>


### PR DESCRIPTION
While form data is invalid, the Save button is disabled, which causes the enabled Delete button to trigger when Enter is pressed.
