### PR TITLE
docs(index): include required ngRoute script

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
       </div>
     </div>
     <div class=" row example">
-      <div class="span8 app-source" app-source="project.html project.js list.html detail.html" resource="resource" firebase="firebase" annotate="project.annotation" module="project"></div>
+      <div class="span8 app-source" app-source="project.html project.js list.html detail.html" resource="resource" route="route" firebase="firebase" annotate="project.annotation" module="project"></div>
       <div class="span4">
         <span hint></span>
         <span class="pull-right" js-fiddle="project.html list.html detail.html project.js" resource="resource" module="project"></span>

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -84,6 +84,7 @@ angular.module('homepage', [])
     return {
       angular: '<script src="https://ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular.min.js"></script>\n',
       resource: '<script src="https://ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular-resource.min.js"></script>\n',
+      route: '<script src="https://ajax.googleapis.com/ajax/libs/angularjs/' + angular.version.full + '/angular-route.min.js"></script>\n',
       firebase: '<script src="https://cdn.firebase.com/v0/firebase.js"></script>\n    <script src="https://cdn.firebase.com/libs/angularfire/0.5.0/angularfire.min.js"></script>\n'
     };
   })
@@ -149,6 +150,7 @@ angular.module('homepage', [])
                 '  <head>\n' +
                 '    ' + script.angular +
                (attrs.resource ? ('    ' + script.resource.replace('></', '>\n    </')) : '') +
+               (attrs.route ? ('    ' + script.route.replace('></', '>\n   </')) : '') +
                (attrs.firebase ? ('    ' + script.firebase) : '') +
                 '__HEAD__' +
                 '  </head>\n' +


### PR DESCRIPTION
The demo on the homepage using ngRoute was apparently not including the 
angular-route script, which has been separate from angular core for some time
now. This seems to have confused some people in the Freenode channel.

**I can't seem to test this locally**, but it seems like these changes should be
enough to make it clear that the angular-route script needs to be loaded.
