### PR TITLE
docs(index): include bootstrap in components example

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
       </div>
     </div>
     <div class=" row example">
-      <div class="span8 app-source" app-source="tabs.html components.js app.js" annotate="tabs.annotation" module="app"></div>
+      <div class="span8 app-source" app-source="tabs.html components.js app.js bootstrap.css" annotate="tabs.annotation" module="app"></div>
       <div class="span4">
         <span hint></span>
         <span class="pull-right" js-fiddle="tabs.html components.js app.js" module="app"></span>
@@ -763,6 +763,9 @@
         }
       });
     </script>
+    <style type="text/css" id="bootstrap.css">
+      @import '//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css';
+    </style>
     <script type="text/ng-template" id="tabs.html">
       <tabs>
         <pane title="Localization">


### PR DESCRIPTION
The docs on the homepage for the component example requires bootstrap.css in
order to work properly. See angular/angular.js/#1258 for the original
discussion.

This ends up looking like this:
![angularjs superheroic javascript mvw framework 2014-01-20 07-00-06](https://f.cloud.github.com/assets/28543/1954647/2b8a4ee6-81db-11e3-8ecd-35c39ea6bf11.png)
