### PR TITLE
fix(jsFiddle): Use Bootstrap CDN instead of broken GitHub URL

### DIFF
--- a/js/homepage.js
+++ b/js/homepage.js
@@ -245,7 +245,7 @@ angular.module('homepage', [])
       terminal: true,
       link: function(scope, element, attr) {
         var name = '',
-            stylesheet = '<link rel="stylesheet" href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css">\n',
+            stylesheet = '<link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css">\n',
             fields = {
               html: '',
               css: '',


### PR DESCRIPTION
The Bootstrap CSS link on the jsFiddle directive seems to be broken -- I assume Twitter finally pulled it from their Github site. Updated to use 2.3.2 on a CDN.
