### PR TITLE
docs(index): check for $pristine in 'wire up a backend' example

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,17 +625,17 @@
     </script>
     <script type="text/ng-template" id="detail.html">
       <form name="myForm">
-        <div class="control-group" ng-class="{error: myForm.name.$invalid}">
+        <div class="control-group" ng-class="{error: myForm.name.$invalid && !myForm.name.$pristine}">
           <label>Name</label>
           <input type="text" name="name" ng-model="project.name" required>
-          <span ng-show="myForm.name.$error.required" class="help-inline">
-              Required</span>
+          <span ng-show="myForm.name.$error.required && !myForm.name.$pristine" class="help-inline">
+              Required {{myForm.name.$pristine}}</span>
         </div>
 
-        <div class="control-group" ng-class="{error: myForm.site.$invalid}">
+        <div class="control-group" ng-class="{error: myForm.site.$invalid && !myForm.site.$pristine}">
           <label>Website</label>
           <input type="url" name="site" ng-model="project.site" required>
-          <span ng-show="myForm.site.$error.required" class="help-inline">
+          <span ng-show="myForm.site.$error.required && !myForm.name.$pristine" class="help-inline">
               Required</span>
           <span ng-show="myForm.site.$error.url" class="help-inline">
               Not a URL</span>


### PR DESCRIPTION
Reference https://github.com/angular/angular.js/issues/1746

The docs on the homepage for the 'wire up a backend' example need to check the $pristine value of the form element before setting the error class or showing the 'required' help text.

**Before**:
![angularjs superheroic javascript mvw framework 2014-01-21 20-41-25](https://f.cloud.github.com/assets/28543/1970864/0fbffd9a-8317-11e3-8be3-1b26f287b579.png)

**After**:
![angularjs superheroic javascript mvw framework 2014-01-21 20-41-44](https://f.cloud.github.com/assets/28543/1970865/1afeab34-8317-11e3-8d3a-08f58af1c952.png)
