### PR TITLE
Remove trailing slash from link to api docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
               <ul class="dropdown-menu">
                 <li><a href="http://docs.angularjs.org/tutorial">Tutorial</a></li>
                 <li><a href="http://docs.angularjs.org/guide/">Developer Guide</a></li>
-                <li><a href="http://docs.angularjs.org/api/">API Reference</a></li>
+                <li><a href="http://docs.angularjs.org/api">API Reference</a></li>
                 <li><a href="http://docs.angularjs.org/misc/contribute">Contribute</a></li>
                 <li><a href="http://code.angularjs.org/">Download</a></li>
               </ul>


### PR DESCRIPTION
The trailing slash results in the docs trying to load a non-existent page.
