### PR TITLE
fix(index.html): Image link should use relative path

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -142,7 +142,7 @@
           </ul>
 
           <a class="learn-link" href="http://angular.codeschool.com">
-            <img class="learn-link-badge" src="/img/codeschool-badge.png" alt="Shaping up with Angular.js" width="52" height="52" />
+            <img class="learn-link-badge" src="img/codeschool-badge.png" alt="Shaping up with Angular.js" width="52" height="52" />
             Learn Angular in your browser for free!
           </a>
         </div>
@@ -154,7 +154,7 @@
     <div class="container about-container">
       <div class="ng-europe-banner jumbo-banner">
         <a href="http://ngeurope.org/" target="_blank" rel="nofollow" class="ng-europe-logo">
-          <img src="/img/ng-europe-logo-compact-on-white.png" />
+          <img src="img/ng-europe-logo-compact-on-white.png" />
         </a>
         <div class="jumbo-banner-content">
           <h2 class="heading">


### PR DESCRIPTION
Some images are using prefix / and it shouldn't as there is already the <base href> element which is set to /
Then the prefix is changed by using this base href element
