### PR TITLE
Update download button and modal with 1.4 plus npm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,15 +21,15 @@ function replaceInFile {
 }
 
 function getCdnVersions {
-  CDN_VERSION_1_2=$(./get-cdn-version.sh 1.2)
   CDN_VERSION_1_3=$(./get-cdn-version.sh 1.3)
+  CDN_VERSION_1_4=$(./get-cdn-version.sh 1.4)
 }
 
 function replaceCdnVersionInFiles {
   for FILE in "${CDN_REPLACE_FILES[@]}"
   do
-    replaceInFile $FILE '${CDN_VERSION_1_2}' $CDN_VERSION_1_2
     replaceInFile $FILE '${CDN_VERSION_1_3}' $CDN_VERSION_1_3
+    replaceInFile $FILE '${CDN_VERSION_1_4}' $CDN_VERSION_1_4
   done
 }
 
@@ -37,7 +37,7 @@ function replaceCdnVersionInFiles {
 
 function testBuildResult {
   export ANGULAR_HOME_HOST='http://localhost:8100';
-  export ANGULAR_DOWNLOAD_VERSIONS="$CDN_VERSION_1_2:1.2.x $CDN_VERSION_1_3:1.3.x"
+  export ANGULAR_DOWNLOAD_VERSIONS="$CDN_VERSION_1_3:1.3.x $CDN_VERSION_1_4:1.4.x"
   export ANGULAR_VERSION="$CDN_VERSION_1_3"
   export CHECK_SCRIPT_TAG="true"
 

--- a/src/js/download-data.js
+++ b/src/js/download-data.js
@@ -2,14 +2,14 @@ angular.module('download-data', [])
 
 .value('BRANCHES', [
     {
-      branch: '1.2.*', version: '${CDN_VERSION_1_2}',
-      title: '1.2.x (legacy)',
-      cssClass: 'branch-1-2-x'
+      branch: '1.3.*', version: '${CDN_VERSION_1_3}',
+      title: '1.3.x (stable)',
+      cssClass: 'branch-1-3-x'
     },
     {
-      branch: '1.3.*', version: '${CDN_VERSION_1_3}',
-      title: '1.3.x (latest)',
-      cssClass: 'branch-1-3-x'
+      branch: '1.4.*', version: '${CDN_VERSION_1_4}',
+      title: '1.4.x (latest)',
+      cssClass: 'branch-1-4-x'
     }
 ])
 
@@ -22,10 +22,10 @@ angular.module('download-data', [])
 .value('DOWNLOAD_INFO', {
   branchesInfo:
     "<dl class='dl-horizontal'>"+
-    "  <dt>Legacy 1.2.x</dt>"+
-    "  <dd>This branch is in maintenance mode. It is stable and the API will not undergo any further changes. New releases will only contain bug-fixes.</dd>"+
+    "  <dt>Latest 1.4.x</dt>"+
+    "  <dd>This branch is the actively-developed feature branch (<a href='https://github.com/angular/angular.js/tree/master' target='_blank'>master on Github</a>), not yet considered stable.</dd>"+
     "  <dt>Stable 1.3.x</dt>"+
-    "  <dd>This is the latest stable branch, with regular bug fixes, performance improvements and small features added.</dd>"+
+    "  <dd>This is the latest stable branch (<a href='https://github.com/angular/angular.js/tree/v1.3.x' target='_blank'>v1.3.x on Github</a>), with regular bug fixes, performance improvements and small features added.</dd>"+
     "</dl>",
 
   buildsInfo:

--- a/src/partials/download-modal.html
+++ b/src/partials/download-modal.html
@@ -77,6 +77,14 @@
         </a>
       </dd>
 
+      <dt>npm</dt>
+      <dd>
+        <span class="pull-left">
+          <input class="input-xxlarge" type="text" readonly="readonly"
+                  value="npm install angular@{{currentBranch.version}}">
+        </span>
+      </dd>
+
       <dt>Extras</dt>
       <dd>
         <span class="pull-left">


### PR DESCRIPTION
I updated and ran E2E tests, and manually tested this locally:

 * Checked that download button reads: "1.3.10 / 1.4.0-beta.1"
 * Checked that download modal lists 1.3.x as stable (and default selection), 1.4.x as latest
 * Verified urls/versions/package names in the download modal fields
 * I also added an npm field, without a description of npm, and copy-paste-tested stable and latest installation in another project.