### PR TITLE
Fixed two description typos on front page.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -254,7 +254,7 @@
         <p>
           Unlike other frameworks, there is no need to inherit from proprietary types in order to wrap the
           model in accessors methods. Angular models are plain old JavaScript objects. This makes your code easy to
-          test, maintain, reuse, and again free from boilerplate.
+          test, maintain, and reuse, again and again, free from boilerplate.
         </p>
       </div>
     </div>
@@ -287,7 +287,7 @@
       <div class="span4">
         <h3>Deep Linking</h3>
         <p>
-          A deep link reflects where the user is in the app, this is useful so users can bookmark
+          A deep link reflects where the user is in the app. This is useful so users can bookmark
           and email links to locations within apps. Round trip apps get this automatically, but
           AJAX apps by their nature do not. AngularJS combines the benefits of deep link with
           desktop app-like behavior.


### PR DESCRIPTION
While reading through the Angular front page, I noticed two typos that could hinder readability for users. Since they are on the front page, they seemed worth changing in order to make the documentation as clear and polished as possible for new users.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angularjs.org/169)
<!-- Reviewable:end -->
