### PR TITLE
Fix for Issue #130

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -204,6 +204,7 @@ img.cache {
 
 .well h1.ng-binding {
   margin: 0;
+  word-wrap: break-word;
 }
 
 .no-margins {


### PR DESCRIPTION
Fix for Issue #130 

In 'The Basics' section of the website, the printed text used to exceed the screen limit instead of going to next line. This is now fixed by using word-wrap.

Here is the screenshot of how it looks after the fix:
![issue 130](https://cloud.githubusercontent.com/assets/4054338/8453767/deec1896-1fc5-11e5-81f3-51909424534c.PNG)
p.