### PR TITLE
feat: add 1.5.x to download modal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,7 @@ function replaceInFile {
 function getCdnVersions {
   CDN_VERSION_1_2=$(./get-cdn-version.sh 1.2)
   CDN_VERSION_1_4=$(./get-cdn-version.sh 1.4)
+  CDN_VERSION_1_5=$(./get-cdn-version.sh 1.5)
 }
 
 function replaceCdnVersionInFiles {
@@ -30,6 +31,7 @@ function replaceCdnVersionInFiles {
   do
     replaceInFile $FILE '${CDN_VERSION_1_2}' $CDN_VERSION_1_2
     replaceInFile $FILE '${CDN_VERSION_1_4}' $CDN_VERSION_1_4
+    replaceInFile $FILE '${CDN_VERSION_1_5}' $CDN_VERSION_1_5
   done
 }
 
@@ -37,7 +39,7 @@ function replaceCdnVersionInFiles {
 
 function testBuildResult {
   export ANGULAR_HOME_HOST='http://localhost:8100';
-  export ANGULAR_DOWNLOAD_VERSIONS="$CDN_VERSION_1_2:1.2.x $CDN_VERSION_1_4:1.4.x"
+  export ANGULAR_DOWNLOAD_VERSIONS="$CDN_VERSION_1_2:1.2.x $CDN_VERSION_1_4:1.4.x $CDN_VERSION_1_5:1.5.x"
   export ANGULAR_VERSION="$CDN_VERSION_1_4"
   export CHECK_SCRIPT_TAG="true"
 

--- a/src/js/download-data.js
+++ b/src/js/download-data.js
@@ -10,7 +10,12 @@ angular.module('download-data', [])
       branch: '1.2.*', version: '${CDN_VERSION_1_2}',
       title: '1.2.x (legacy)',
       cssClass: 'branch-1-2-x'
-    }
+    },
+    {
+      branch: '1.5.*', version: '${CDN_VERSION_1_5}',
+      title: '1.5.x (beta)',
+      cssClass: 'branch-1-5-x'
+    },
 ])
 
 .value('BUILDS', [
@@ -22,10 +27,12 @@ angular.module('download-data', [])
 .value('DOWNLOAD_INFO', {
   branchesInfo:
     "<dl class='dl-horizontal'>"+
-    "  <dt>Latest 1.4.x</dt>"+
+    "  <dt>Stable 1.4.x</dt>"+
     "  <dd>This is the latest stable branch (<a href='https://github.com/angular/angular.js/tree/master' target='_blank'>master on Github</a>), with regular bug fixes.</dd>"+
     "  <dt>Legacy 1.2.x</dt>"+
-    "  <dd>This branch contains a legacy version of AngularJS that supported IE8 (<a href='https://github.com/angular/angular.js/tree/v1.2.x' target='_blank'>v1.2.x on Github</a>), only essential bug fixes will appear here.</dd>"+
+    "  <dd>This branch contains a legacy version of AngularJS that supports IE8 (<a href='https://github.com/angular/angular.js/tree/v1.2.x' target='_blank'>v1.2.x on Github</a>).</dd>"+
+    "  <dt>Beta 1.5.x</dt>"+
+    "  <dd>This is the currently active development branch (<a href='https://github.com/angular/angular.js/tree/v1.5.x' target='_blank'>v1.2.x on Github</a>), which receives new features and may contain breaking changes.</dd>"+
     "</dl>",
 
   buildsInfo:


### PR DESCRIPTION
I think this should be all that's needed to display 1.5.x download links in the download modal. Hard to check though!

/cc @petebacondarwin 