### PR TITLE
Overflow problem fixed

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -204,6 +204,7 @@ img.cache {
 
 .well h1.ng-binding {
   margin: 0;
+  word-break: break-all;
 }
 
 .no-margins {


### PR DESCRIPTION
I fixed the overflow problem in "The Basics" area example.

Old: 
<img width="714" alt="old" src="https://cloud.githubusercontent.com/assets/330566/11441819/6d334e36-9518-11e5-89e2-f38e81662f45.png">

New:
<img width="437" alt="new" src="https://cloud.githubusercontent.com/assets/330566/11441824/737146f4-9518-11e5-8eef-d4a66fc284b7.png">

