### PR TITLE
fix: remove 1.2 from dl button, expand description in modal

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -117,7 +117,7 @@
           <a class="btn btn-large btn-primary" href="" ng-click="showDownloadModal()">
             <i class="icon-download-alt icon-large"></i> Download
             <span class="version" ng-cloak>
-              (<span ng-repeat="branch in BRANCHES | filter:{branch: '!1.2.*'}">{{branch.version}}{{ !$last ? ' / ' : '' }}</span>)
+              (<span ng-repeat="branch in BRANCHES | filter:{showOnButton: true}">{{branch.version}}{{ !$last ? ' / ' : '' }}</span>)
             </span>
           </a>
           <a class="btn btn-large btn-warning" href="http://goo.gl/sj0Nk1" target="_blank">

--- a/src/index.html
+++ b/src/index.html
@@ -117,7 +117,7 @@
           <a class="btn btn-large btn-primary" href="" ng-click="showDownloadModal()">
             <i class="icon-download-alt icon-large"></i> Download
             <span class="version" ng-cloak>
-              (<span ng-repeat="branch in BRANCHES">{{branch.version}}{{ !$last ? ' / ' : '' }}</span>)
+              (<span ng-repeat="branch in BRANCHES | filter:{branch: '!1.2.*'}">{{branch.version}}{{ !$last ? ' / ' : '' }}</span>)
             </span>
           </a>
           <a class="btn btn-large btn-warning" href="http://goo.gl/sj0Nk1" target="_blank">

--- a/src/js/download-data.js
+++ b/src/js/download-data.js
@@ -32,7 +32,8 @@ angular.module('download-data', [])
     "  <dt>Stable 1.4.x</dt>"+
     "  <dd>This is the latest stable branch (<a href='https://github.com/angular/angular.js/tree/v1.4.x' target='_blank'>v1.4.x on Github</a>), with regular bug fixes.</dd>"+
     "  <dt>Legacy 1.2.x</dt>"+
-    "  <dd>This branch contains a legacy version of AngularJS that supports IE8 (<a href='https://github.com/angular/angular.js/tree/v1.2.x' target='_blank'>v1.2.x on Github</a>).</dd>"+
+    "  <dd>This branch contains a legacy version of AngularJS that supports IE8 (<a href='https://github.com/angular/angular.js/tree/v1.2.x' target='_blank'>v1.2.x on Github</a>)." +
+    "      It is not actively developed and will only receive security fixes. It is not recommended for new applications</dd>"+
     "</dl>",
 
   buildsInfo:

--- a/src/js/download-data.js
+++ b/src/js/download-data.js
@@ -4,17 +4,20 @@ angular.module('download-data', [])
     {
       branch: '1.5.*', version: '${CDN_VERSION_1_5}',
       title: '1.5.x (beta)',
-      cssClass: 'branch-1-5-x'
+      cssClass: 'branch-1-5-x',
+      showOnButton: true
     },
     {
       branch: '1.4.*', version: '${CDN_VERSION_1_4}',
       title: '1.4.x (stable)',
-      cssClass: 'branch-1-4-x'
+      cssClass: 'branch-1-4-x',
+      showOnButton: true
     },
     {
       branch: '1.2.*', version: '${CDN_VERSION_1_2}',
       title: '1.2.x (legacy)',
-      cssClass: 'branch-1-2-x'
+      cssClass: 'branch-1-2-x',
+      showOnButton: false
     },
 ])
 


### PR DESCRIPTION
1.2 should still be easily available for download, but we
don't want to advertise for it on the homepage. It should also be
clear that it is not actively developed