### PR TITLE
fix: links in "Wire up a Backend" example

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -692,7 +692,7 @@
         },
         {
           name: 'Backbone',
-          site: 'http://documentcloud.github.com/backbone/',
+          site: 'http://backbonejs.org/',
           description: 'Models for your apps.'
         },
         {
@@ -712,7 +712,7 @@
         },
         {
           name: 'Cappucino',
-          site: 'http://cappuccino.org/',
+          site: 'http://www.cappuccino-project.org/',
           description: 'Objective-J.'
         },
         {
@@ -722,7 +722,7 @@
         },
         {
           name: 'GWT',
-          site: 'https://developers.google.com/web-toolkit/',
+          site: 'http://www.gwtproject.org/',
           description: 'JS in Java.'
         },
         {


### PR DESCRIPTION
Backbone has a dead link, Cappucino and GWT use redirection.