### PR TITLE
test(tabs): account for BC in AngularJS v1.5.1

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -950,9 +950,9 @@
     <script type="text/ng-template" id="tabs.html">
       <tabs>
         <pane title="Localization">
-          Date: {{ '2012-04-01' | date:'fullDate' }} <br>
-          Currency: {{ 123456 | currency }} <br>
-          Number: {{ 98765.4321 | number }} <br>
+          <span>Date: {{ '2012-04-01' | date:'fullDate' }}</span><br>
+          <span>Currency: {{ 123456 | currency }}</span><br>
+          <span>Number: {{ 98765.4321 | number }}</span><br>
         </pane>
         <pane title="Pluralization">
           <div ng-controller="BeerCounter">


### PR DESCRIPTION
Due to a breaking change in v1.5.1 (introduced in https://github.com/angular/angular.js/commit/7617c08da69a0d447507dadd0ef41d2415462ca7), a CSS selector in `test/angularjs.org.spec.js` couldn't find the targeted element and failed.
This commit fixes the proble by manaully wrapping the text nodes in `<span>` elements.