### PR TITLE
feat(popovers): show code annotation popovers on hover

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -558,3 +558,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#eeeeee', end
   border: 0;
   opacity: 0.4;
 }
+
+.code-annotation {
+  cursor: help;
+}

--- a/src/js/homepage.js
+++ b/src/js/homepage.js
@@ -260,13 +260,15 @@ angular.module('homepage', ['ngAnimate', 'ui.bootstrap', 'download-data'])
             scope['popover' + index + counter] = $sce.trustAsHtml(text);
 
             content = content.replace(regexp, function(_, before, token, after) {
-              token = "__" + (counter) + "__";
+              token = '__' + counter + '__';
               popovers[token] =
-                '<span class="nocode"\n' +
-                '      popover-title="' + escape(key) + '"\n' +
-                '      popover-trigger="outsideClick"\n' +
-                '      popover-append-to-body="true"\n' +
-                '      uib-popover-html="popover' + index + counter + '"><code>' + escape(key) + '</code>' +
+                '<span ' +
+                    'class="nocode code-annotation" ' +
+                    'popover-append-to-body="true" ' +
+                    'popover-trigger="mouseenter" ' +
+                    'popover-title="' + escape(key) + '" ' +
+                    'uib-popover-html="popover' + index + counter + '">' +
+                  '<code>' + escape(key) + '</code>' +
                 '</span>';
               return before + token + after;
             });
@@ -369,9 +371,17 @@ angular.module('homepage', ['ngAnimate', 'ui.bootstrap', 'download-data'])
 
   .directive('hint', function() {
     return {
-      template: '<em>Hint:</em> Click ' +
-          '<code class="nocode" popover-title="Hover" popover-trigger="outsideClick" popover-append-to-body="true"' +
-          'uib-popover="Click highlighted areas in the code for explanations.">me</code>.'
+      template:
+        '<em>Hint:</em> ' +
+          'hover over ' +
+          '<code ' +
+              'class="nocode code-annotation" ' +
+              'popover-append-to-body="true" ' +
+              'popover-trigger="mouseenter" ' +
+              'popover-title="Hover" ' +
+              'uib-popover="Place your mouse over highlighted areas in the code for explanations.">' +
+            'me' +
+          '</code>.'
     };
   })
 


### PR DESCRIPTION
The code annotation/explanation popovers are shown on hover (instead of on click) for easier access. (Note they don't contain any clickable content.)
The download modal popovers are still shown/hidden on click, so the user can click on links in their body.

Fixes #197