### PR TITLE
chore(build): fix version matching RegExps

### DIFF
--- a/scripts/get-cdn-version.js
+++ b/scripts/get-cdn-version.js
@@ -8,7 +8,7 @@ const utils = require('./utils');
 
 // Constants
 const GIT_REMOTE = 'https://github.com/angular/angular.js.git';
-const VERSION_REGEXP = /^(\d+)\.(\d+)\.(\d+)(?:-([^.]+)\.(\d+))?$/;
+const VERSION_REGEXP = /^(\d+)\.(\d+)\.(\d+)(?:-?([^.\d]+)\.?(\d+))?$/;
 
 // Exports
 module.exports = getCdnVersion;
@@ -52,7 +52,7 @@ function getAngularVersions(version) {
   // cfffd1cd5607c0df03720614221c6b0e9c3e8189  refs/tags/v1.5.3
   // 514639b585affc218a6899f1b1755863647fa5a8  refs/tags/v1.5.3^{}
   // ...
-  const versionRegExp = new RegExp(`v(${version.replace(/\./g, '\\.')}\\..*\\d)\\s*$`, 'gi');
+  const versionRegExp = new RegExp(`v(${version.replace(/\./g, '\\.')}\\..*\\d)\\s*$`, 'i');
 
   return utils.
     execAsPromised(`git ls-remote --tags ${GIT_REMOTE}`).


### PR DESCRIPTION
This commit fixes two problems:

1. The RegExp in `getAngularVersions()` incorrectly had the `g` flag set, which resulted in failing
   to recognize valid versions. By chance it worked almost correctly, because of how `git ls-remote`
   lists lightweight tags **and** their dereferenced commits. But it failed after annotated tags
   (which aren't dereferenced).
2. It was assumed that pre-release versions always have the form `v1.2.3-xyz.4`. It turned out that
   some older versions (e.g. on the 1.2.x branch) may omit the `-` and the last `.`.