### PR TITLE
Make plnkr.co link https

### DIFF
--- a/src/js/homepage.js
+++ b/src/js/homepage.js
@@ -364,7 +364,7 @@ angular.module('homepage', ['ngAnimate', 'ui.bootstrap', 'download-data'])
 
             postData.description = 'AngularJS Example: ' + name;
 
-            formPostData('http://plnkr.co/edit/?p=preview', newWindow, postData);
+            formPostData('https://plnkr.co/edit/?p=preview', newWindow, postData);
           };
         };
       }


### PR DESCRIPTION
When visiting https://angularjs.org and clicking the "Edit Me" button, a browser security warning pops up, as data is attempting to be sent via unsecured HTTP. This PR sets the request to use HTTPS instead, to eliminate the browser warning.