### PR TITLE
Fix bootstrap https

### DIFF
--- a/src/js/homepage.js
+++ b/src/js/homepage.js
@@ -321,7 +321,7 @@ angular.module('homepage', ['ngAnimate', 'ui.bootstrap', 'download-data'])
           var ctrl = this;
 
           var name = '',
-            bootstrapStylesheet = 'http://netdna.bootstrapcdn.com/twitter-bootstrap/2.0.4/css/bootstrap-combined.min.css',
+            bootstrapStylesheet = '//netdna.bootstrapcdn.com/twitter-bootstrap/2.0.4/css/bootstrap-combined.min.css',
             plnkrFiles = [];
 
           angular.forEach(ctrl.files.split(' '), function(filename, index) {


### PR DESCRIPTION
Bootstrap in the plnkr examples is not loading over https, but since plnkr is the resource is getting blocked.