### PR TITLE
docs(eol): Add EOL options text and link to page banner

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -88,12 +88,8 @@
     <nav id="navbar-notice" class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <p class="site-notice visible-phone">
-            This site refers to AngularJS (v1.x). <a href="https://angular.io/">Go to the latest Angular</a>.
-          </p>
-          <p class="site-notice visible-desktop">
-            This site and all of its contents are referring to AngularJS (version 1.x),
-            if you are looking for the latest Angular, please visit <a href="https://angular.io/">angular.io</a>.
+          <p class="site-notice">
+            AngularJS is now in Long Term Support (LTS) mode: <a href="https://docs.angularjs.org/misc/version-support-status">Find out more</a>. Explore End Of Life (EOL) options <a href="https://blog.angular.io/finding-a-path-forward-with-angularjs-7e186fdd4429">here</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
### Changes:
* Remove "_This site and all of its contents are referring to AngularJS (version 1.x)..._" text from page banner.
* Add "_Explore End Of Life (EOL) options here_" text to page banner.

### Previous banner text:
![image](https://user-images.githubusercontent.com/5667395/144877801-ebe4b229-60b5-4e50-92f1-9c2ce61d52b4.png)

### New banner text
![image](https://user-images.githubusercontent.com/5667395/144877939-b24dc603-fbad-414e-b231-18572e76d85d.png)

![image](https://user-images.githubusercontent.com/5667395/144877970-6537a87e-0924-46fb-86d4-121d96dd7c25.png)
